### PR TITLE
Sanitize file name

### DIFF
--- a/jquery.MultiFile.js
+++ b/jquery.MultiFile.js
@@ -456,7 +456,7 @@ if (window.jQuery)(function ($) {
 					
 					var names = $('<span/>');
 					$.each(files, function (i, file) {
-						var v = String(file.name || '' ),
+						var v = String(file.name || '' ).replace(/[&<>'"]/g, function(c) { return '&#'+c.charCodeAt()+';'; }),
 								S = MultiFile.STRING,
 								n = S.label || S.file || S.name,
 								t = S.title || S.tooltip || S.selected,


### PR DESCRIPTION
fixes #41 

File names are not sanitized before display.

This can lead to some fun XSS:
name a file `abc"<img src="a" onerror="alert('haxxored');">def.jpg` and open it with the demo page.

Any of these chars `&<>"'` in a file name is likely to produce display problems at least