### PR TITLE
Fix file count comparison

### DIFF
--- a/jquery.MultiFile.js
+++ b/jquery.MultiFile.js
@@ -243,7 +243,7 @@ if (window.jQuery)(function ($) {
 
 					// If we've reached maximum number, disable input slave
 					var disable_slave;
-					if ((MultiFile.max > 0) && ((MultiFile.files.length) > (MultiFile.max))) {
+					if ((MultiFile.max > 0) && ((MultiFile.files.length) >= (MultiFile.max))) {
 						slave.disabled = true;
 						disable_slave = true;
 					};


### PR DESCRIPTION
When the length is equal to the max the next input should be disabled.